### PR TITLE
Fix the underscore protocol's string implementation

### DIFF
--- a/src/inflections/core.cljx
+++ b/src/inflections/core.cljx
@@ -586,7 +586,12 @@
   #+clj java.lang.String
   #+cljs string
   (-underscore [obj]
-    (replace obj #"-" "_")))
+    (-> obj
+        (replace #"::" "/")
+        (replace #"([A-Z\d]+)([A-Z][a-z])" "$1_$2")
+        (replace #"([a-z\d])([A-Z])" "$1_$2")
+        (replace #"-" "_")
+        lower-case)))
 
 (defn underscore
   "The reverse of camelize. Makes an underscored, lowercase form from

--- a/test/inflections/core_test.cljx
+++ b/test/inflections/core_test.cljx
@@ -419,8 +419,10 @@
     (= (c/underscore word) expected)
     nil nil
     "" ""
-    "weather.nww3-htsgwsfc-2013-02-04T00"
-    "weather.nww3_htsgwsfc_2013_02_04T00"))
+    "weather.nww3-htsgwsfc-2013-02-04T00" "weather.nww3_htsgwsfc_2013_02_04_t00"
+    "ActiveRecord" "active_record"
+    "ActiveRecord::Errors" "active_record/errors"
+))
 
 (deftest test-stringify-keys
   (are [m expected]


### PR DESCRIPTION
The behavior of underscore was at odds both with ActiveSupport's
behavior as well as its own documentation. This fixes the common cases,
omitting only ActiveSupport's internal acronyms registry.

Note that it does change an existing test case to be consistent with
ActiveSupport's actual behavior on the input, so this would seem to
change behavior about which someone cares. If so, you may want to reject
this and simply correct the documentation.
