### PR TITLE
Improved acronym stuff

### DIFF
--- a/src/inflections/core.cljx
+++ b/src/inflections/core.cljx
@@ -341,7 +341,6 @@
   (-capitalize [x]
     (cond
       (acronym x) (acronym x)
-      (acronym (singular x)) (plural (acronym (singular x)))
       :else
       (str (upper-case (str (first x)))
            (when (next x) (lower-case (subs x 1)))))))

--- a/test/inflections/core_test.cljx
+++ b/test/inflections/core_test.cljx
@@ -50,6 +50,7 @@
 
 (deftest test-capitalize
   (c/add-acronym! "HST")
+  (c/add-acronym! "PhDs")
   (are [word expected]
     (= (c/capitalize word) expected)
     nil nil
@@ -62,7 +63,8 @@
     :HELLO :Hello
     "123ABC" "123abc"
     :123ABC :123abc
-    "hsts" "HSTs"))
+    "hsts" "Hsts"
+    "phds" "PhDs"))
 
 (deftest test-dasherize
   (are [word expected]


### PR DESCRIPTION
Turns out that not all acronyms are all upper case.
