### PR TITLE
Remove support for double-colon Rubyisms

### DIFF
--- a/src/inflections/core.cljc
+++ b/src/inflections/core.cljc
@@ -253,9 +253,7 @@
 (defn camel-case
   "Convert `word` to camel case. By default, camel-case converts to
   UpperCamelCase. If the argument to camel-case is set to :lower then
-  camel-case produces lowerCamelCase. The camel-case fn will also
-  convert \"/\" to \"::\" which is useful for converting paths to
-  namespaces.
+  camel-case produces lowerCamelCase.
 
   Examples:
 
@@ -266,10 +264,10 @@
     ;=> \"activeRecord\"
 
     (camel-case \"active_record/errors\")
-    ;=> \"ActiveRecord::Errors\"
+    ;=> \"ActiveRecord/Errors\"
 
     (camel-case \"active_record/errors\" :lower)
-    ;=> \"activeRecord::Errors\""
+    ;=> \"activeRecord/Errors\""
   [word & [mode]]
   (when word
     (->> (let [word (str-name word)]
@@ -278,7 +276,7 @@
              (= mode :upper) (camel-case word upper-case)
              (fn? mode) (str (mode (str (first word)))
                              (apply str (rest (camel-case word nil))))
-             :else (-> (replace word #"/(.?)" #(str "::" (upper-case (nth % 1))))
+             :else (-> (replace word #"/(.?)" #(str "/" (upper-case (nth % 1))))
                        (replace #"(^|_|-)(.)"
                                 #?(:clj
                                    #(str (if (#{\_ \-} (nth % 1))
@@ -360,7 +358,7 @@
     ; => \"country-flag\""
   [x]
   (when x
-    (->> (-> (replace (str-name x) #"::" "/")
+    (->> (-> (str-name x)
              (replace #"([A-Z]+)([A-Z][a-z])" "$1-$2")
              (replace #"([a-z\d])([A-Z])" "$1-$2")
              (replace #"\s+" "-")
@@ -421,8 +419,7 @@
 
 (defn underscore
   "The reverse of camel-case. Makes an underscored, lowercase form from
-  the expression in the string. Changes \"::\" to \"/\" to convert
-  namespaces to paths.
+  the expression in the string.
 
   Examples:
 
@@ -430,10 +427,10 @@
     ;=> \"active_record\"
 
     (underscore \"ActiveRecord::Errors\")
-    ;=> \"active_record/errors\""
+    ;=> \"active_record::errors\""
   [x]
   (when x
-    (->> (-> (replace (str-name x) #"::" "/")
+    (->> (-> (str-name x)
              (replace #"([A-Z\d]+)([A-Z][a-z])" "$1_$2")
              (replace #"([a-z\d])([A-Z])" "$1_$2")
              (replace #"-" "_")

--- a/test/inflections/core_test.cljc
+++ b/test/inflections/core_test.cljc
@@ -33,7 +33,7 @@
     nil nil
     "" ""
     "active_record" "ActiveRecord"
-    "active_record/errors" "ActiveRecord::Errors")
+    "active_record/errors" "ActiveRecord/Errors")
   (are [word expected]
       (= (c/camel-case word :lower) expected)
     nil nil
@@ -41,7 +41,7 @@
     "active_record" "activeRecord"
     :active_record :activeRecord
     'active_record 'activeRecord
-    "active_record/errors" "activeRecord::Errors"
+    "active_record/errors" "activeRecord/Errors"
     "product" "product"
     "special_guest" "specialGuest"
     "application_controller" "applicationController"
@@ -125,6 +125,7 @@
     "Street Address" "street-address"
     "SpecialGuest" "special-guest"
     "ApplicationController" "application-controller"
+    "ActiveRecord::Base" "active-record::base"
     "Area51Controller" "area51-controller"
     "HTMLTidy" "html-tidy"
     "HTMLTidyGenerator" "html-tidy-generator"
@@ -380,7 +381,7 @@
     "ActiveRecord" "active_record"
     :ActiveRecord :active_record
     'ActiveRecord 'active_record
-    "ActiveRecord::Errors" "active_record/errors"
+    "ActiveRecord::Errors" "active_record::errors"
     :titles/site-name :titles/site_name))
 
 (deftest test-stringify-keys


### PR DESCRIPTION
I wonder if it's confusing to even mention the ActiveSupport-style Rubyisms in docstrings etc. now.

Fixes #18. Feedback welcome.