### PR TITLE
feat(clojure): add deps.edn support, use clojure 1.11.1 parse-long, remove "encore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ lib
 /pom.xml.asc
 /.repl
 /.nrepl-port
+/.cpcache

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps  {org.clojure/clojure {:mvn/version "1.11.1"}}}

--- a/src/inflections/core.cljc
+++ b/src/inflections/core.cljc
@@ -1,8 +1,7 @@
 (ns inflections.core
   (:refer-clojure :exclude [replace])
   (:require [clojure.string :refer [blank? lower-case upper-case replace split join]]
-            [clojure.walk :refer [keywordize-keys]]
-            [no.en.core :refer [parse-integer]]))
+            [clojure.walk :refer [keywordize-keys]]))
 
 (defn coerce
   "Coerce the string `s` to the type of `obj`."
@@ -378,7 +377,7 @@
     (ordinalize \"23\")
     ;=> \"23rd\""
   [x]
-  (if-let [number (parse-integer x)]
+  (if-let [number (parse-long x)]
     (if (contains? (set (range 11 14)) (mod number 100))
       (str number "th")
       (let [modulus (mod number 10)]


### PR DESCRIPTION
Modernized a lib a bit by removing a now obsolete dependency for a clojure.core fn.
This raises the minimum required clojure version to to 1.11.0, as `parse-long` was added with it:
https://github.com/clojure/clojure/blob/master/changes.md#changes-to-clojure-in-version-1110

This avoids the warnings like:
```
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: spec-coerce.core, being replaced by: #'spec-coerce.core/parse-long
WARNING: parse-double already refers to: #'clojure.core/parse-double in namespace: spec-coerce.core, being replaced by: #'spec-coerce.core/parse-double
WARNING: parse-uuid already refers to: #'clojure.core/parse-uuid in namespace: spec-coerce.core, being replaced by: #'spec-coerce.core/parse-uuid
WARNING: parse-boolean already refers to: #'clojure.core/parse-boolean in namespace: spec-coerce.core, being replaced by: #'spec-coerce.core/parse-boolean
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: no.en.core, being replaced by: #'no.en.core/parse-long
WARNING: parse-double already refers to: #'clojure.core/parse-double in namespace: no.en.core, being replaced by: #'no.en.core/parse-double
```
from the previous transitive dependency.

Until this is merged you can use my fork to use it with deps.edn + latest clojure version:
```
        ;; until https://github.com/r0man/inflections-clj/pull/24 is merged
        inflections/inflections {:git/url "https://github.com/thenonameguy/inflections-clj"
                                 :sha     "bfbf5d891e27634f3cfe0c61aab6a1dd5e1b01d1"}
```

