### PR TITLE
Fix clojure 11 warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,8 @@
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[noencore "0.3.6"]
-                 [org.clojure/clojure "1.10.0"]
-                 [org.clojure/clojurescript "1.10.439" :scope "provided"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/clojurescript "1.11.51" :scope "provided"]]
   :aliases {"ci" ["do"
                   ["test"]
                   ["doo" "phantom" "none" "once"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject inflections "0.13.3-SNAPSHOT"
+(defproject inflections "0.14.0-SNAPSHOT"
   :description "Rails-like inflections for Clojure(Script)."
   :url "http://github.com/r0man/inflections-clj"
   :author "r0man"

--- a/src/inflections/core.cljc
+++ b/src/inflections/core.cljc
@@ -1,8 +1,7 @@
 (ns inflections.core
   (:refer-clojure :exclude [replace])
   (:require [clojure.string :refer [blank? lower-case upper-case replace split join]]
-            [clojure.walk :refer [keywordize-keys]]
-            [no.en.core :refer [parse-integer]]))
+            [clojure.walk :refer [keywordize-keys]]))
 
 (defn coerce
   "Coerce the string `s` to the type of `obj`."
@@ -378,15 +377,16 @@
     (ordinalize \"23\")
     ;=> \"23rd\""
   [x]
-  (if-let [number (parse-integer x)]
-    (if (contains? (set (range 11 14)) (mod number 100))
-      (str number "th")
-      (let [modulus (mod number 10)]
-        (cond
-          (= modulus 1) (str number "st")
-          (= modulus 2) (str number "nd")
-          (= modulus 3) (str number "rd")
-          :else (str number "th"))))))
+  (when x
+    (if-let [number (if (number? x) x (parse-long x))]
+      (if (contains? (set (range 11 14)) (mod number 100))
+        (str number "th")
+        (let [modulus (mod number 10)]
+          (cond
+            (= modulus 1) (str number "st")
+            (= modulus 2) (str number "nd")
+            (= modulus 3) (str number "rd")
+            :else (str number "th")))))))
 
 (defn parameterize
   "Replaces special characters in `x` with the default separator


### PR DESCRIPTION
This PR fixes the following warnings on projects using Clojure 11 that depend on inflections-clj:

```sh
WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: no.en.core, being replaced by: #'no.en.core/parse-long
WARNING: parse-double already refers to: #'clojure.core/parse-double in namespace: no.en.core, being replaced by: #'no.en.core/parse-double
```

It does so by actually removing the noencore dependency, replacing the parse-integer usage by Clojure 11's new parse-long. I bumped the project version to 0.14.0 since Clojure 11 now will be required.