### PR TITLE
Undo Clojure bump and restore noencore usage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,9 @@
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.11.1"]]
+  :dependencies [[noencore "0.3.7"]
+                 [org.clojure/clojure "1.10.0"]
+                 [org.clojure/clojurescript "1.10.439" :scope "provided"]]
   :aliases {"ci" ["do"
                   ["test"]
                   ["doo" "node" "none" "once"]

--- a/src/inflections/core.cljc
+++ b/src/inflections/core.cljc
@@ -1,7 +1,8 @@
 (ns inflections.core
   (:refer-clojure :exclude [replace])
   (:require [clojure.string :refer [blank? lower-case upper-case replace split join]]
-            [clojure.walk :refer [keywordize-keys]]))
+            [clojure.walk :refer [keywordize-keys]]
+            [no.en.core :refer [parse-integer]]))
 
 (defn coerce
   "Coerce the string `s` to the type of `obj`."
@@ -377,16 +378,15 @@
     (ordinalize \"23\")
     ;=> \"23rd\""
   [x]
-  (when x
-    (if-let [number (if (number? x) x (parse-long x))]
-      (if (contains? (set (range 11 14)) (mod number 100))
-        (str number "th")
-        (let [modulus (mod number 10)]
-          (cond
-            (= modulus 1) (str number "st")
-            (= modulus 2) (str number "nd")
-            (= modulus 3) (str number "rd")
-            :else (str number "th")))))))
+  (if-let [number (parse-integer x)]
+    (if (contains? (set (range 11 14)) (mod number 100))
+      (str number "th")
+      (let [modulus (mod number 10)]
+        (cond
+          (= modulus 1) (str number "st")
+          (= modulus 2) (str number "nd")
+          (= modulus 3) (str number "rd")
+          :else (str number "th"))))))
 
 (defn parameterize
   "Replaces special characters in `x` with the default separator


### PR DESCRIPTION
I believe this is actually a better approach to solving Clojure 11 warnings. The reason is that many projects that still did not migrate might be using this lib, so it's probably too early to force them to upgrade it, and using new functions such as `parse-long` effectively does so.